### PR TITLE
Do not unlink unrelated files during symlink extraction

### DIFF
--- a/lib/untar.c
+++ b/lib/untar.c
@@ -781,7 +781,7 @@ tar_extract_symlink(TAR *t, char *filename)
 	if (mkdirhier(t, filename) == -1)
 		return -1;
 
-	if (unlink(filename) == -1 && errno != ENOENT)
+	if (unlinkat(t->dirfd, filename, 0) == -1 && errno != ENOENT)
 		return -1;
 
 #ifdef DEBUG


### PR DESCRIPTION
Previously the prefix given to `tar_extract_all` was ignored and
an unrelated file relative to the process current working directory
was unlinked instead.