### PR TITLE
fix build with recent glibc

### DIFF
--- a/lib/libuntar.h
+++ b/lib/libuntar.h
@@ -15,6 +15,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <tar.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
Build fails with recent glibc:

untar.c: In function ‘tar_extract_chardev’:
untar.c:819:5: warning: implicit declaration of function ‘makedev’ [-Wimplicit-function-declaration
  819 |     makedev(devmaj, devmin)) == -1)
      |     ^~~~~~~

Include `sys/sysmacros.h` to fix this.